### PR TITLE
docs: clarify API_TOKEN administrator contract

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -324,6 +324,8 @@ moviepilot tool show run_slash_command
 
 因此，智能助手是“有工具的智能体”，但不是“无条件的超级管理员”。
 
+外部管理员级集成需要单独理解：MCP 以及 OpenAI / Anthropic 兼容的 Agent API 使用 `API_TOKEN` 认证，持有该密钥的客户端会被视为受信任的管理员级 Agent 集成。它不同于普通登录用户在 WEB 页面里的 UI 权限，也不会因为某个普通用户会话而自动收窄能力范围。只应把 `API_TOKEN` 配置给你信任的客户端、网关或自动化系统。
+
 # 图片、文件与语音
 
 ## 图片输入

--- a/configuration.md
+++ b/configuration.md
@@ -131,7 +131,7 @@ V1版本有些进阶配置参数需要通过配置文件进行配置（不配置
 - **FRONTEND_PATH：** 前端静态文件路径，默认为 `/public`，Docker 官方镜像和本地 CLI 会自动维护
 - **❗SUPERUSER：** 超级管理员用户名，默认`admin`，安装后使用该用户登录后台管理界面。**注意：仅在首次安装时生效！**
 - **SUPERUSER_PASSWORD：** 超级管理员初始密码，`v2.8.0+`版本才支持，仅在首次安装时生效，不配置时系统会自动生成随机密码，随机密码会在首次启动的日志中打印。**注意：仅在首次安装时生效！**
-- **❗API_TOKEN：** API密钥，V1版本默认为`moviepilot`，**V2版本需要配置为大于等于16个字符的复杂字符串** （如配置不符合要求将会强制重新生成，可在后台日志、env配置文件或系统设定中查看最新的值） 。在媒体服务器Webhook、微信回调等地址配置中需要加上`?token=`该值。第三方 Agent 工具接入 MoviePilot MCP 时，也使用同一个 `API_TOKEN` 认证，参考 [MCP](/mcp)。
+- **❗API_TOKEN：** API密钥，V1版本默认为`moviepilot`，**V2版本需要配置为大于等于16个字符的复杂字符串** （如配置不符合要求将会强制重新生成，可在后台日志、env配置文件或系统设定中查看最新的值） 。在媒体服务器Webhook、微信回调等地址配置中需要加上`?token=`该值。第三方 Agent 工具接入 MoviePilot MCP，以及调用 OpenAI / Anthropic 兼容 Agent API 时，也使用同一个 `API_TOKEN` 认证。请将它视为管理员级 secret，不要分享给不受信第三方客户端；远程接入优先使用请求头并配合 HTTPS、访问控制和网络隔离，参考 [MCP](/mcp)。
 - **DEBUG：** 是否调试模式，默认为 `false`
 - **APP_DOMAIN：** 应用域名，格式为 `https://movie-pilot.org`，默认为空
 - **ADVANCED_MODE：** 高级设置模式，`v2.8.0+`版本才支持，默认为 `true`，开启后会显示全部设置选项，否则仅显示设置向导，引导完成简化设置。
@@ -410,7 +410,7 @@ api.themoviedb.org,api.tmdb.org,webservice.fanart.tv,api.github.com,github.com,r
 | 基础 | `SUPERUSER` | `admin` | 首次启动环境变量/配置文件 | 超级管理员用户名，仅首次安装生效 |
 | 基础 | `SUPERUSER_PASSWORD` | 随机生成 | 首次启动环境变量/配置文件 | 超级管理员初始密码，仅首次安装生效 |
 | 基础 | `APP_DOMAIN` | 空 | `设定 -> 系统 -> 基础设置` | 外部访问域名 |
-| 基础 | `API_TOKEN` | 自动生成 | `设定 -> 系统 -> 基础设置` | API、Webhook、MCP 认证密钥 |
+| 基础 | `API_TOKEN` | 自动生成 | `设定 -> 系统 -> 基础设置` | API、Webhook、MCP、兼容 Agent API 认证密钥 |
 | 基础 | `DEBUG` | `false` | `设定 -> 系统 -> 进阶设置` | 调试日志与调试模式 |
 | 基础 | `ADVANCED_MODE` | `true` | 环境变量/配置文件 | 是否显示完整设置 |
 | 基础 | `DEV` | `false` | 环境变量/配置文件 | 本地开发模式 |

--- a/mcp.md
+++ b/mcp.md
@@ -20,10 +20,13 @@ MoviePilot 已内置标准 `MCP (Model Context Protocol)` 服务，第三方 Age
 # 连接前先确认这几件事
 
 1. MoviePilot 已正常运行，并且第三方 Agent 工具能访问到 MoviePilot 的 API 地址。
-2. 你已经拿到 `API_TOKEN`，它就是 MCP 的认证密钥。
+2. 你已经拿到 `API_TOKEN`，它就是 MCP 的认证密钥，也是管理员级凭证。
 3. 你使用的是 `API` 端口，默认是 `3001`，不是前端页面端口 `3000`。
 
 `API_TOKEN` 可在系统设置中查看或修改，也可以从启动日志中搜索 `API_TOKEN` 获取。关于 `API_TOKEN` 的说明可参考 [基础](/basic)。
+
+> 持有 `API_TOKEN` 的 MCP 客户端可调用 MoviePilot 通过 MCP 暴露的业务工具。只把它配置给你信任的 Agent 工具或受控网关，不要交给不受信第三方服务。
+{.is-warning}
 
 常见地址示例：
 
@@ -56,6 +59,9 @@ MoviePilot 已内置标准 `MCP (Model Context Protocol)` 服务，第三方 Age
 - 如果客户端只能配置 URL、不能配置自定义请求头，可以退而求其次把 `API_TOKEN` 放到 `?apikey=` 查询参数里。
 
 > 推荐优先使用请求头认证，不建议把 `API_TOKEN` 直接写进 URL，因为 URL 更容易出现在日志、历史记录或截图里。
+{.is-warning}
+
+> 如果需要让远程 Agent 访问 MoviePilot MCP，请先完成 HTTPS、访问控制、网络隔离或反向代理鉴权等部署防护，不要把带有管理员级凭证保护的接口直接裸露到公网。
 {.is-warning}
 
 # 先用简单请求验证是否可用
@@ -208,7 +214,7 @@ moviepilot tool show search_torrents
 moviepilot tool show add_subscribe
 ```
 
-> 出于安全考虑，MoviePilot 不会通过 MCP 暴露 `execute_command`、`search_web`、`edit_file`、`write_file`、`read_file` 这类本地高风险工具。第三方 Agent 拿到的是 MoviePilot 业务能力相关的工具集，而不是系统级任意读写执行权限。
+> 出于安全考虑，MoviePilot 不会通过 MCP 暴露 `execute_command`、`search_web`、`edit_file`、`write_file`、`read_file` 这类本地高风险工具。第三方 Agent 拿到的是 MoviePilot 业务能力相关的工具集，而不是系统级任意读写执行权限。隐藏这些本地高风险工具只是收敛 MCP 暴露面，不代表 `API_TOKEN` 支持按用户划分的细粒度权限。
 {.is-info}
 
 # 常见问题
@@ -258,9 +264,10 @@ MoviePilot 这边优先按远程 HTTP MCP 使用。
 可以，但强烈建议：
 
 - 使用 `HTTPS`
+- 在反向代理、网关或网络层增加访问控制，只允许可信客户端访问
 - 不要把 `API_TOKEN` 写进公开仓库或公开截图
 - 不要把带 `apikey=` 的 URL 随意分享
-- 把 `API_TOKEN` 视为高敏感凭证保管
+- 把 `API_TOKEN` 视为管理员级高敏感凭证保管
 
 # 相关文档
 


### PR DESCRIPTION
## 变更说明

补充 `API_TOKEN` 在 MCP 和兼容 Agent API 中的管理员级凭证说明，强调持有者应视为受信管理员级集成客户端。

## 影响范围

- `configuration.md`
- `mcp.md`
- `agent.md`

## 兼容性

仅更新公开文档，不改变 MoviePilot 运行时行为。

## 验证

- `git diff --check`

本 PR 为 Codex 协作提交
