### PR TITLE
docs: 补充 Docker 优雅停止时间建议

### DIFF
--- a/install.md
+++ b/install.md
@@ -21,6 +21,8 @@ MoviePilot在docker境像中同时还内置了`虚拟显示`、`浏览器仿真`
 
 V3 正式版镜像为 `jxxghp/moviepilot-v3:latest`，也可以将标签替换为具体的 `3.0.0` 等版本号。下例为全新安装路径；从 V2 切换时，将 `/moviepilot-v3/config` 替换为原 V2 配置目录即可复用数据。
 
+V3 停止时会依次关闭后台任务、插件和其他运行模块。建议为容器预留 `120` 秒优雅停止时间，避免 Docker 使用默认的较短等待时间强制终止仍在收尾的进程。
+
 ```shell
 docker run -itd \
     --name moviepilot-v3 \
@@ -40,6 +42,7 @@ docker run -itd \
     -e 'TZ=Asia/Shanghai' \
     -e 'SUPERUSER=admin' \
     -e 'SUPERUSER_PASSWORD=你的初始登录密码' \
+    --stop-timeout 120 \
     --restart always \
     jxxghp/moviepilot-v3:latest
 ```
@@ -134,6 +137,7 @@ services:
       - 'CACHE_BACKEND_TYPE=redis'
       - 'CACHE_BACKEND_URL=redis://:redis_password@redis:6379'
     restart: always
+    stop_grace_period: 120s
     depends_on:
       postgresql:
         condition: service_healthy

--- a/upgrade.md
+++ b/upgrade.md
@@ -22,6 +22,8 @@ V2 容器的内建重启升级不会直接跨主版本升级到 V3。需要先�
 
 V3 使用独立镜像仓库。使用 Docker Compose 时，先将 Compose 文件中 `moviepilot` 服务的 `image` 改为 `jxxghp/moviepilot-v3:latest`，再执行：
 
+建议同时为 MoviePilot 服务设置 `stop_grace_period: 120s`，让镜像重建前的容器停止过程有足够时间完成后台任务和模块收尾。使用 `docker run` 或 `docker create` 部署时设置 `--stop-timeout 120`。
+
 ```bash
 docker compose pull moviepilot
 docker compose up --force-recreate -d moviepilot


### PR DESCRIPTION
## 说明

MoviePilot V3 停止时需要依次关闭后台任务、插件和其他运行模块。Docker 默认的较短停止等待时间可能在收尾完成前强制终止容器，因此补充 120 秒优雅停止时间的部署建议。

## 改动

- 在 V3 `docker run` 示例中增加 `--stop-timeout 120`
- 在 V3 Compose 示例中增加 `stop_grace_period: 120s`
- 在 V3 镜像升级说明中同步两种部署方式的配置建议

## 验证

- `git diff --check`
