### PR TITLE
chore: add q10710/MoviePilot-Plugins to public plugin market list

### DIFF
--- a/plugin.md
+++ b/plugin.md
@@ -106,6 +106,7 @@ dateCreated: 2024-06-11T22:35:11.803Z
 - https://github.com/SAGIRIxr/MoviePilot-Plugins
 - https://github.com/irab-liu/MoviePilot-Plugins
 - https://github.com/changzhanghs/MoviePilot-Plugins
+- https://github.com/q10710/MoviePilot-Plugins
 <!-- plugin-market-repos:end -->
 
 以上清单可在插件市场设置中点击“同步 Wiki”自动合并到本地配置。同步时会与本地已有仓库去重，保留本地顺序并追加 Wiki 中新增的公开仓库。


### PR DESCRIPTION
新增公开插件仓库到可同步清单。

**仓库地址**：https://github.com/q10710/MoviePilot-Plugins

**仓库情况**：
- 公开仓库，默认分支 `main`
- 根目录含 `package.v2.json`、`icons/`、`plugins.v2/`，插件元数据完整（name / description / icon / author / history）
- 当前收录 9 个插件：订阅助手Q自用版、H&R助手Q自用版、站点流量管理Q自用版、自动限速Q自用版、做种守卫Q自用版、硬链接检查Q自用版、洗版守护Q自用版、过期订阅清理Q自用版、删档订阅清理Q自用版
- 部分插件为官方 / 第三方插件的自用改造版，README 中已标注上游来源

**PR 内容**：仅在 `<!-- plugin-market-repos:start -->` … `<!-- plugin-market-repos:end -->` 区间末尾追加一行仓库地址，未改动其他内容。

谢谢！
